### PR TITLE
Magento 2.2x Compatibility

### DIFF
--- a/Bugsnag/Handler.php
+++ b/Bugsnag/Handler.php
@@ -44,7 +44,7 @@ class Handler extends AbstractProcessingHandler
     /**
      * @param Bugsnag_Client|Client $bugsnagClient
      * @param int $level The minimum logging level at which this handler will be triggered
-     * @param Boolean $bubble Whether the messages that are handled can bubble up the stack or not
+     * @param \Monolog\Handler\Boolean $bubble Whether the messages that are handled can bubble up the stack or not
      * @param Config $config
      */
     public function __construct(

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "interjar/bugsnag",
   "description": "Magento 2 Bugsnag for remote debugging",
   "require": {
-    "magento/framework": "100.1.*|100.2.*",
+    "magento/framework": "100.*|101.*",
     "magento/magento-composer-installer": "*",
     "bugsnag/bugsnag": "^3.4"
   },

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "bugsnag/bugsnag": "^3.4"
   },
   "type": "magento2-module",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "license": "MIT",
   "autoload": {
     "files": [

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,7 @@
   "name": "interjar/bugsnag",
   "description": "Magento 2 Bugsnag for remote debugging",
   "require": {
-    "php": "~5.6.5|7.0.2|7.0.4|~7.0.6",
-    "magento/framework": "100.1.*",
+    "magento/framework": "100.1.*|100.2.*",
     "magento/magento-composer-installer": "*",
     "bugsnag/bugsnag": "^3.4"
   },


### PR DESCRIPTION
- Composer Dependencies Updated by @adamj88 
- DI Compilation errors fixed by @josh-carter

To be released as interjar/bugsnag 2.2.0 or 3.3.0?

@adamj88 correct versioning to `3.3.0`?