### PR TITLE
Reuse the configuration instance & don't fetch release stage when not needed

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -63,7 +63,9 @@ class Config
      */
     public function getConfiguration()
     {
-        if(isset($this->bugsnagConfig) && is_array($this->bugsnagConfig)) {
+        if ($this->config instanceof Configuration) {
+            return $this->config;
+        } else if(isset($this->bugsnagConfig) && is_array($this->bugsnagConfig)) {
             $apiKey = $this->getApiKey();
             $releaseStage = $this->getReleaseStage();
             if ($apiKey) {

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -67,9 +67,9 @@ class Config
             return $this->config;
         } else if(isset($this->bugsnagConfig) && is_array($this->bugsnagConfig)) {
             $apiKey = $this->getApiKey();
-            $releaseStage = $this->getReleaseStage();
             if ($apiKey) {
                 $this->config = new Configuration($apiKey);
+                $releaseStage = $this->getReleaseStage();
                 if ($releaseStage) {
                     $this->config->setReleaseStage($releaseStage);
                 }


### PR DESCRIPTION
If I'm correct there is no need to build the configuration every time getConfiguration is called. 
Just reuse the one set in the attribute `config`.

Also moved the `$this->getReleaseStage()` call to after the creation of the Configuration, as it isn't needed otherwise.