### PR TITLE
Add support for catching exceptions in cronjobs

### DIFF
--- a/Plugin/BaseExceptionCatcherPlugin.php
+++ b/Plugin/BaseExceptionCatcherPlugin.php
@@ -1,17 +1,19 @@
 <?php
 /**
- * Plugin to catch any uncaught exceptions
- *
  * @author Josh Carter <josh@interjar.com>
  */
+
 namespace Interjar\BugSnag\Plugin;
 
-use Magento\Framework\App\Http;
-use Magento\Framework\App\Bootstrap;
-use Interjar\BugSnag\Helper\Config;
 use Bugsnag\Client;
+use Interjar\BugSnag\Helper\Config;
 
-class ExceptionCatcher
+/**
+ * Base class for any ExceptionCatcher plugin.
+ *
+ * @package Interjar\BugSnag\Plugin
+ */
+abstract class BaseExceptionCatcherPlugin
 {
 
     /**
@@ -28,30 +30,22 @@ class ExceptionCatcher
      */
     public function __construct(
         Config $config
-    )
-    {
+    ) {
         $this->config = $config;
     }
 
     /**
-     * Catch any exceptions and notify an instance of \Bugsnag\Client
+     * Handle an exception and attempt to send it to Bugsnag.
      *
-     * @param Http $subject
-     * @param Bootstrap $bootstrap
      * @param \Exception $exception
-     *
-     * @return array
      */
-    public function beforeCatchException(
-        Http $subject,
-        Bootstrap $bootstrap,
+    protected function handleException(
         \Exception $exception
-    )
-    {
-        if($this->config->getConfiguration()) {
+    ) {
+        if ($this->config->getConfiguration()) {
             $client = new Client($this->config->getConfiguration(), null, Client::makeGuzzle());
             $client->notifyException($exception);
         }
-        return [$bootstrap, $exception];
     }
+
 }

--- a/Plugin/CronExceptionCatcher.php
+++ b/Plugin/CronExceptionCatcher.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Plugin to catch any uncaught exceptions in Cron jobs.
+ *
+ * @author Josh Carter <josh@interjar.com>
+ */
+
+namespace Interjar\BugSnag\Plugin;
+
+use Magento\Framework\App\Bootstrap;
+use Magento\Framework\App\Cron;
+
+class CronExceptionCatcher extends BaseExceptionCatcherPlugin
+{
+
+    /**
+     * Catch any exceptions and notify an instance of \Bugsnag\Client
+     *
+     * @param Cron $subject
+     * @param Bootstrap $bootstrap
+     * @param \Exception $exception
+     *
+     * @return array
+     */
+    public function beforeCatchException(
+        Cron $subject,
+        Bootstrap $bootstrap,
+        \Exception $exception
+    ) {
+        $this->handleException($exception);
+
+        return [$bootstrap, $exception];
+    }
+
+}

--- a/Plugin/HttpExceptionCatcher.php
+++ b/Plugin/HttpExceptionCatcher.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Plugin to catch any uncaught exceptions in the HTTP layer,
+ *
+ * @author Josh Carter <josh@interjar.com>
+ */
+
+namespace Interjar\BugSnag\Plugin;
+
+use Magento\Framework\App\Bootstrap;
+use Magento\Framework\App\Http;
+
+class HttpExceptionCatcher extends BaseExceptionCatcherPlugin
+{
+
+    /**
+     * Catch any exceptions and notify an instance of \Bugsnag\Client
+     *
+     * @param Http $subject
+     * @param Bootstrap $bootstrap
+     * @param \Exception $exception
+     *
+     * @return array
+     */
+    public function beforeCatchException(
+        Http $subject,
+        Bootstrap $bootstrap,
+        \Exception $exception
+    ) {
+        $this->handleException($exception);
+
+        return [$bootstrap, $exception];
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -17,6 +17,9 @@
         </arguments>
     </type>
     <type name="Magento\Framework\App\Http">
-        <plugin disabled="false" name="ExceptionCatcher" type="\Interjar\BugSnag\Plugin\ExceptionCatcher" sortOrder="0"/>
+        <plugin disabled="false" name="ExceptionCatcher" type="\Interjar\BugSnag\Plugin\HttpExceptionCatcher" sortOrder="0"/>
+    </type>
+    <type name="Magento\Framework\App\Cron">
+        <plugin disabled="false" name="Interjar_BugSnag_ExceptionCatcher" type="\Interjar\BugSnag\Plugin\CronExceptionCatcher" sortOrder="0" />
     </type>
 </config>


### PR DESCRIPTION
I've reworked the `ExceptionCatcher` to a base class that can be extended by any other plugin. All they have to do is call `handleException()` to process an exception. Then added plugins for the HTTP app & for the Cron app.

This is possibly a breaking change as we've removed the `ExceptionCatcher` class. I could rework it to just adding another class next to the default ExceptionCatcher that catches cron exceptions.